### PR TITLE
Add title_color and body_color to feed_item

### DIFF
--- a/lib/mondo/feed_item.rb
+++ b/lib/mondo/feed_item.rb
@@ -6,7 +6,9 @@ module Mondo
                   :url, # TODO - make me consistent when the Mondo API changes
                   :background_color,
                   :body,
-                  :type
+                  :type,
+                  :title_color,
+                  :body_color
 
 
     # temporary fix until the API accepts JSON data in the request body
@@ -23,7 +25,9 @@ module Mondo
           title: self.title,
           image_url: self.image_url,
           background_color: self.background_color,
-          body: self.body
+          body: self.body,
+          title_color: self.title_color,
+          body_color: self.body_color
         }
       }
     end


### PR DESCRIPTION
Going through the API i noticed that the params title_color & body_color are available but weren't exposed in the gem, this PR adds them in as params to pass in.

This replaces #9  as I accidentally added in another commit for a different PR :disappointed: 
