### PR TITLE
Use ActiveSupport extensions

### DIFF
--- a/lib/mondo/client.rb
+++ b/lib/mondo/client.rb
@@ -1,5 +1,4 @@
-require 'active_support/all' # really only need core_ext/hash
-
+require 'active_support/core_ext/hash'
 require 'multi_json'
 require 'oauth2'
 require 'openssl'
@@ -16,7 +15,7 @@ module Mondo
     attr_accessor :access_token, :account_id, :api_url
 
     def initialize(args = {})
-      Utils.symbolize_keys! args
+      args.symbolize_keys!
       self.access_token = args.fetch(:token)
       self.account_id = args.fetch(:account_id, nil)
       self.api_url = args.fetch(:api_url, DEFAULT_API_URL)

--- a/lib/mondo/utils.rb
+++ b/lib/mondo/utils.rb
@@ -12,18 +12,5 @@ module Mondo
     def underscore(str)
       str.gsub(/(.)([A-Z])/) { "#{$1}_#{$2.downcase}" }.downcase
     end
-
-    # Hash Helpers
-    def symbolize_keys(hash)
-      symbolize_keys! hash.dup
-    end
-
-    def symbolize_keys!(hash)
-      hash.keys.each do |key|
-        sym_key = key.to_s.to_sym rescue key
-        hash[sym_key] = hash.delete(key) unless hash.key?(sym_key)
-      end
-      hash
-    end
   end
 end

--- a/mondo.gemspec
+++ b/mondo.gemspec
@@ -4,10 +4,10 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'oauth2', '~> 1.0'
   gem.add_runtime_dependency 'money'
   gem.add_runtime_dependency 'multi_json', '~> 1.10'
+  gem.add_runtime_dependency 'activesupport', '~> 3.2'
 
   gem.add_development_dependency 'rspec', '~> 2.13'
   gem.add_development_dependency 'yard', '~> 0.8'
-  gem.add_development_dependency 'activesupport', '~> 3.2'
   gem.add_development_dependency 'rake', '~> 10.3'
 
   gem.authors = ['Tom Blomfield']


### PR DESCRIPTION
Currently the gem uses `active_support/all` and like the note says it only needs `core_ext/hash` so this implements that.

I also noticed that ActiveSupport is set as a development dependency but as we are requiring it in the lib I imagine it should be in there as a runtime dep.

And finally as we are just using ActiveSupport Hash has a method for symbolizing keys, we should use rather than writing one in Utils.
