### PR TITLE
Object#to_param is used in Client#request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :development do
+group :development, :test do
+  gem "fakeweb"
   gem "guard", "~> 0.8.8"
   gem "rspec", "~> 3.1"
   if RUBY_PLATFORM.downcase.include?("darwin")

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem "fakeweb"
   gem "guard", "~> 0.8.8"
   gem "rspec", "~> 3.1"
   if RUBY_PLATFORM.downcase.include?("darwin")

--- a/README.md
+++ b/README.md
@@ -146,8 +146,12 @@ mondo.create_feed_item(
 
 ## Tests
 
+```
+bundle exec rake spec
+```
+
 We need some tests. See "Contributing"
 
 ## Contributing
 
-Pull requests welcome! 
+Pull requests welcome!

--- a/lib/mondo/client.rb
+++ b/lib/mondo/client.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/hash'
+require 'active_support/core_ext/object/to_query'
 require 'multi_json'
 require 'oauth2'
 require 'openssl'

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe Mondo do
-  before do
-  end
-
   describe 'Hash' do
     describe '#to_param' do
       it 'should return params string for a hash' do
@@ -15,16 +12,10 @@ describe Mondo do
   describe 'Client' do
     describe '#request' do
       it "It should not throw an error when opts param are supplied" do
-        FakeWeb.allow_net_connect = false
-        FakeWeb.register_uri(:get, 'https://api.getmondo.co.uk/accounts', body: {accounts: {id: 'acc_123', description: 'Mark Watney', created: '2015-11-13T12:17:42Z'}}.to_json, content_type: 'application/javascript')
-        FakeWeb.register_uri(:post, 'https://api.getmondo.co.uk/attachment/register', content_type: 'application/javascript')
-        client = Mondo::Client.new(token: 'theuserstoken')
-        opts = {
-          external_id: 'tx_123',
-          file_url: 'https://url-to-an-image.com/image.png',
-          file_type: 'image/png',
-        }
-        expect(client.api_post("attachment/register", opts)).to be_a(Mondo::Response)
+        client = Mondo::Client.new(token: "token", account_id: "id")
+        resp = instance_double(Faraday::Response, body: '', status: 200)
+        allow(client.connection).to receive(:run_request).and_return(resp)
+        expect(client.api_post("attachment/register", {})).to be_a(Mondo::Response)
       end
     end
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -4,9 +4,28 @@ describe Mondo do
   before do
   end
 
-  describe "tests" do
-    it "run" do
-      expect(1+1).to eq(2)
+  describe 'Hash' do
+    describe '#to_param' do
+      it 'should return params string for a hash' do
+        expect({hello: 'world', great: 'day'}.to_param).to eq('great=day&hello=world')
+      end
+    end
+  end
+
+  describe 'Client' do
+    describe '#request' do
+      it "It should not throw an error when opts param are supplied" do
+        FakeWeb.allow_net_connect = false
+        FakeWeb.register_uri(:get, 'https://api.getmondo.co.uk/accounts', body: {accounts: {id: 'acc_123', description: 'Mark Watney', created: '2015-11-13T12:17:42Z'}}.to_json, content_type: 'application/javascript')
+        FakeWeb.register_uri(:post, 'https://api.getmondo.co.uk/attachment/register', content_type: 'application/javascript')
+        client = Mondo::Client.new(token: 'theuserstoken')
+        opts = {
+          external_id: 'tx_123',
+          file_url: 'https://url-to-an-image.com/image.png',
+          file_type: 'image/png',
+        }
+        expect(client.api_post("attachment/register", opts)).to be_a(Mondo::Response)
+      end
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,17 +1,9 @@
 require 'spec_helper'
 
 describe Mondo do
-  describe 'Hash' do
-    describe '#to_param' do
-      it 'should return params string for a hash' do
-        expect({hello: 'world', great: 'day'}.to_param).to eq('great=day&hello=world')
-      end
-    end
-  end
-
   describe 'Client' do
     describe '#request' do
-      it "It should not throw an error when opts param are supplied" do
+      it "should not throw an error when opts param are supplied" do
         client = Mondo::Client.new(token: "token", account_id: "id")
         resp = instance_double(Faraday::Response, body: '', status: 200)
         allow(client.connection).to receive(:run_request).and_return(resp)
@@ -20,4 +12,3 @@ describe Mondo do
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,2 @@
 require 'active_support/hash_with_indifferent_access'
 require './lib/mondo'
-require 'fakeweb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require 'active_support/hash_with_indifferent_access'
 require './lib/mondo'
+require 'fakeweb'


### PR DESCRIPTION
`Object#to_param` isn’t included in `active_support/core_ext/hash` as
it’s part of `active_support/core_ext/object/to_query`, so I’ve required
it along with the prior.

If it's not required, an error will be raised when calling `Client#request` with an `opts` parameter as `to_param` is used.
