### PR TITLE
Silence printing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ mondo.create_feed_item(
 )
 ```
 
+## Debug mode
+
+Add `DEBUG` environment variable to print some additional information.
+
 ## Tests
 
 ```

--- a/lib/mondo/client.rb
+++ b/lib/mondo/client.rb
@@ -165,7 +165,7 @@ module Mondo
       @web_hooks ||= begin
         resp = api_get("webhooks", account_id: self.account_id)
 
-        puts resp.inspect
+        puts resp.inspect if ENV['DEBUG']
 
         resp.parsed['webhooks'].map { |hook| WebHook.new(hook, self) }
       end
@@ -200,7 +200,7 @@ module Mondo
       if !opts[:data].nil?
         opts[:body] = opts[:data].to_param
 
-        puts "SETTING BODY #{opts[:body]}"
+        puts "SETTING BODY #{opts[:body]}" if ENV['DEBUG']
 
         opts[:headers]['Content-Type'] = 'application/x-www-form-urlencoded' # sob sob
       end

--- a/lib/mondo/errors.rb
+++ b/lib/mondo/errors.rb
@@ -11,7 +11,7 @@ module Mondo
       @response = response
       @code = response.status
 
-      puts response.inspect
+      puts response.inspect if ENV['DEBUG']
 
       begin
         parsed_response = MultiJson.decode(response.body)


### PR DESCRIPTION
I was writing some automated tests for web hooks and discovered the body of the response gets printed to the console.

While it might be useful to get additional information when needed, it shouldn't be the case that the gem outputs to STDOUT.