### PR TITLE
Add support for pots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1 - August 18, 2018
+
+- Add support for viewing pots
+
 ## 0.4.7 - Novermber 15, 2015
 
 - Fix webhooks bugs

--- a/lib/mondo.rb
+++ b/lib/mondo.rb
@@ -18,4 +18,5 @@ module Mondo
   require 'mondo/merchant'
   require 'mondo/attachment'
   require 'mondo/web_hook'
+  require 'mondo/pot'
 end

--- a/lib/mondo/client.rb
+++ b/lib/mondo/client.rb
@@ -147,6 +147,14 @@ module Mondo
       FeedItem.new(params, self).save
     end
 
+    # @method pots
+    # @return [Pots] all pots for this user
+    def pots(opts = {})
+      resp = api_get("/pots", opts)
+      return resp if resp.error.present?
+      resp.parsed["pots"].map { |p| Pot.new(p, self) }
+    end
+
     def register_web_hook(url)
       raise ClientError.new("You must provide an account id to register webhooks") unless self.account_id
       hook = WebHook.new(

--- a/lib/mondo/pot.rb
+++ b/lib/mondo/pot.rb
@@ -1,0 +1,26 @@
+module Mondo
+  class Pot < Resource
+
+    attr_accessor :id,
+      :name,
+      :style,
+      :balance,
+      :currency,
+      :type,
+      :minimum_balance,
+      :maximum_balance,
+      :round_up
+
+      date_accessor :created
+      date_accessor :updated
+      date_accessor :deleted
+
+    def balance
+      Money.new(raw_data['balance'], currency)
+    end
+
+    def currency
+      Money::Currency.new(raw_data['currency'])
+    end
+  end
+end

--- a/lib/mondo/version.rb
+++ b/lib/mondo/version.rb
@@ -1,3 +1,3 @@
 module Mondo
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.1'.freeze
 end


### PR DESCRIPTION
Currently only listing pots is supported, but deposits and withdrawals could be added in a future PR.