### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ The Mondo Ruby client provides a simple Ruby interface to the Mondo API.
 
 API documentation, usage guides, and setup information can be found at [getmondo.co.uk/docs](https://getmondo.co.uk/docs/).
 
+## Installation
+
+```
+gem install mondo
+```
+
 ## Initialize your client
 
 ```ruby


### PR DESCRIPTION
The name of the repo (`mondo-ruby`) suggests that the name of the gem is `mondo-ruby`, or at least it did to me. This just adds simple installation instructions so it's obvious the gem name is `mondo`